### PR TITLE
 Make dracut iso image bottable 

### DIFF
--- a/createimg1
+++ b/createimg1
@@ -40,6 +40,7 @@ create_img() {
    export DEBOOTSTRAP=mmdebstrap
    export INITRD_GENERATOR=dracut
    export http_proxy=http://127.0.0.1:3142
+   export INITRD_GENERATOR_OPTS='-a dmsquash-live'
 
    sudo cp --verbose ./packages-custom /etc/debootstrap/packages-custom
 

--- a/createimg1
+++ b/createimg1
@@ -60,7 +60,7 @@ create_img() {
          --packages packages-custom \
          --target "/home/$SUDO_USER/grml-debootstraptestbin/test.img"
 
-   chown --recursive user:user /home/$SUDO_USER/grml-debootstraptestbin
+   chown --recursive $SUDO_USER:$SUDO_USER /home/$SUDO_USER/grml-debootstraptestbin
 }
 
 create_img

--- a/image-to-iso
+++ b/image-to-iso
@@ -82,7 +82,7 @@ set default="0"
 set timeout=10
 
 menuentry "Linux" {
-    linux /LiveOS/vmlinuz root=live:CDLABEL=test rd.live.image rd.debug rd.live.debug console=ttyS0
+    linux /LiveOS/vmlinuz root=live:CDLABEL=test rd.live.image rd.debug rd.live.debug rd.live.overlay.overlayfs=1 console=ttyS0
     initrd /LiveOS/initrd.img
 }
 


### PR DESCRIPTION
The `dmsquash-live` module needs to be explicitly added for the live system to be bootable. However, it seems that the overlayfs is not created properly by this module, thus the generated `sysroot.mount` unit is failing. As a workaround, adding the `rd.live.overlay.overlayfs=1` cmdline option seems to do the trick. I could successfully boot the image with these changes.